### PR TITLE
Update README to reference correct webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Getting Started
 
-1. Install WebPack `npm install WebPack -g`
+1. Install WebPack `npm install webpack -g`
 2. Install packages `npm install`
 3. Build extension package `webpack`
 4. Follow this `https://developer.chrome.com/extensions/getstarted#unpacked` to load an unpack extension from the `dist` folder of this repository


### PR DESCRIPTION
```
➜  oc-debug-extension git:(master) ✗ npm install WebPack -g
npm ERR! Darwin 16.4.0
npm ERR! argv "/usr/local/Cellar/node/7.6.0/bin/node" "/usr/local/bin/npm" "install" "WebPack" "-g"
npm ERR! node v7.6.0
npm ERR! npm  v4.1.2

npm ERR! Cannot read property 'path' of null
```

vs

```
➜  oc-debug-extension git:(master) npm install webpack -g
/usr/local/bin/webpack -> /usr/local/lib/node_modules/webpack/bin/webpack.js

> fsevents@1.1.1 install /usr/local/lib/node_modules/webpack/node_modules/fsevents
> node install

[fsevents] Success: ...
```